### PR TITLE
Modify setAttribute  when attribute is an HTML property

### DIFF
--- a/source/compositions.js
+++ b/source/compositions.js
@@ -40,7 +40,7 @@ compositions.setAttribute = (variable, attribute, assignmentExpression) => {
         generators.identifier(variable),
         generators.identifier(mappedAttribute)
       ),
-      generators.literal(true)
+      assignmentExpression
     )
   } else {
     return generators.expressionStatement(

--- a/source/generators.js
+++ b/source/generators.js
@@ -75,6 +75,15 @@ generators.returns = (argument) => {
   }
 }
 
+generators.if = (test, consequent, alternate) => {
+  return {
+    type: 'IfStatement',
+    test,
+    consequent,
+    alternate
+  }
+}
+
 generators.functionExpression = (id, params, body) => {
   return {
     type: 'FunctionExpression',

--- a/source/walkers.js
+++ b/source/walkers.js
@@ -138,8 +138,8 @@ walkers.AssignmentPattern = (node, state, c) => {
 }
 
 walkers.Property = (node, state, c) => {
-  if (node.key) {
-    c(node.key, state, 'Property')
+  if (node.computed) {
+    c(node.key, state, 'Expression')
   }
 
   if (node.value) {
@@ -151,7 +151,7 @@ walkers.Property = (node, state, c) => {
         parent: null
       })
     } else {
-      c(node.value, state, 'Pattern')
+      c(node.value, state, 'Expression')
     }
   }
 }

--- a/test/generators.js
+++ b/test/generators.js
@@ -114,6 +114,19 @@ describe('generators', () => {
     })
   })
 
+  describe('if', () => {
+    it('builds a JavaScript IfStatement', () => {
+      assert.equal(
+        escodegen.generate(generators.if(
+          generators.identifier('true'),
+          generators.literal('hello'),
+          generators.literal('world'))
+        ),
+        "if (true)\n    'hello'\nelse\n    'world'"
+      )
+    })
+  })
+
   describe('contextualClosure', () => {
     it('builds a JavaScript .call-enabled closure', () => {
       assert.equal(

--- a/test/transformers.js
+++ b/test/transformers.js
@@ -205,7 +205,7 @@ describe('transformers', () => {
         assert.deepPropertyVal(
           node,
           'expression.right.value',
-          true
+          'value'
         )
       })
     })

--- a/test/walkers.js
+++ b/test/walkers.js
@@ -355,24 +355,25 @@ describe('walkers', () => {
       recursiveCall = sinon.spy()
     })
 
-    it('walks `key`', () => {
+    it('walks when `key` is a subscripts', () => {
+      node.computed = true
       walkers.Property(node, state, recursiveCall)
       assert.isTrue(recursiveCall.called)
-      assert.isTrue(recursiveCall.calledWith(node.key, state, 'Property'))
+      assert.isTrue(recursiveCall.calledWith(node.key, state, 'Expression'))
     })
 
     it('walks `value`', () => {
       node.value = 'value'
       walkers.Property(node, state, recursiveCall)
       assert.isTrue(recursiveCall.called)
-      assert.isTrue(recursiveCall.calledWith(node.value, state, 'Pattern'))
+      assert.isTrue(recursiveCall.calledWith(node.value, state, 'Expression'))
     })
 
     describe('when `value` is a JSXElement', () => {
       it('walks `value` with initialized state', () => {
         node.value = {type: 'JSXElement'}
         walkers.Property(node, state, recursiveCall)
-        assert.isTrue(recursiveCall.calledTwice)
+        assert.isTrue(recursiveCall.called)
         assert.isTrue(
           recursiveCall.calledWith(
             node.value,


### PR DESCRIPTION
In React, whether a HTML property attribute is effective is rely on his value(true or false)
```javascript
let enable = false;
return (<button type="button" disabled={enable}>Click Me!</button>);
```
the button should be enabled